### PR TITLE
exclude parse-long

### DIFF
--- a/src/compact_uuids/core.clj
+++ b/src/compact_uuids/core.clj
@@ -1,6 +1,6 @@
 (ns compact-uuids.core
   "Compact 26-char URL-safe representation of UUIDs"
-  (:refer-clojure :exclude [str read])
+  (:refer-clojure :exclude [str read parse-long])
   (:import
     [java.util UUID]))
 


### PR DESCRIPTION
Clojure 1.11 introduced a function called `parse-long`.